### PR TITLE
Remove node 10 / sodium-native usage for Windows compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,23 +25,22 @@
     "bs58": "^4.0.1",
     "crypto-ld": "digitalbazaar/crypto-ld#extract-key-pairs",
     "node-forge": "^0.9.1",
-    "semver": "^7.3.2",
-    "sodium-native": "^3.1.1"
+    "semver": "^7.3.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.2",
+    "@babel/core": "^7.10.3",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
-    "@babel/plugin-transform-runtime": "^7.10.1",
-    "@babel/preset-env": "^7.10.2",
-    "@babel/runtime": "^7.10.2",
+    "@babel/plugin-transform-runtime": "^7.10.3",
+    "@babel/preset-env": "^7.10.3",
+    "@babel/runtime": "^7.10.3",
     "babel-loader": "^8.1.0",
     "chai": "^4.2.0",
     "chai-bytes": "^0.1.2",
     "cross-env": "^7.0.2",
-    "eslint": "^7.2.0",
+    "eslint": "^7.3.0",
     "eslint-config-digitalbazaar": "^2.5.0",
-    "eslint-plugin-jsdoc": "^27.0.4",
-    "karma": "^5.0.9",
+    "eslint-plugin-jsdoc": "^27.1.2",
+    "karma": "^5.1.0",
     "karma-babel-preprocessor": "^8.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -49,10 +48,10 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
-    "mocha": "^7.2.0",
+    "mocha": "^8.0.1",
     "mocha-lcov-reporter": "^1.3.0",
-    "multibase": "^0.7.0",
-    "multicodec": "^1.0.1",
+    "multibase": "^1.0.1",
+    "multicodec": "^1.0.2",
     "nyc": "^15.1.0",
     "webpack": "^4.43.0"
   },
@@ -68,14 +67,13 @@
   "browser": {
     "bs58": false,
     "crypto": false,
-    "sodium-native": false,
     "util": false,
     "semver": false,
     "./src/ed25519PublicKeyNode12.js": false,
     "./src/ed25519PrivateKeyNode12.js": false
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "keywords": [
     "Decentralized",

--- a/src/Ed25519VerificationKey2018.js
+++ b/src/Ed25519VerificationKey2018.js
@@ -164,23 +164,6 @@ class Ed25519VerificationKey2018 extends LDVerifierKeyPair {
         ...options
       });
     }
-    if(env.nodejs) {
-      // TODO: use native node crypto api once it's available
-      const sodium = require('sodium-native');
-      const bs58 = require('bs58');
-      const publicKey = new Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
-      const privateKey = new Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
-      if('seed' in options) {
-        sodium.crypto_sign_seed_keypair(publicKey, privateKey, options.seed);
-      } else {
-        sodium.crypto_sign_keypair(publicKey, privateKey);
-      }
-      return new Ed25519VerificationKey2018({
-        publicKeyBase58: bs58.encode(publicKey),
-        privateKeyBase58: bs58.encode(privateKey),
-        ...options
-      });
-    }
 
     const generateOptions = {};
     if('seed' in options) {
@@ -406,25 +389,6 @@ function ed25519SignerFactory(key) {
       }
     };
   }
-  if(env.nodejs) {
-    const sodium = require('sodium-native');
-    const bs58 = require('bs58');
-    const privateKey = util.base58Decode({
-      decode: bs58.decode,
-      keyMaterial: key.privateKeyBase58,
-      type: 'private'
-    });
-    return {
-      async sign({data}) {
-        const signature = Buffer.alloc(sodium.crypto_sign_BYTES);
-        await sodium.crypto_sign_detached(
-          signature,
-          Buffer.from(data.buffer, data.byteOffset, data.length),
-          privateKey);
-        return signature;
-      }
-    };
-  }
 
   // browser implementation
   const privateKey = util.base58Decode({
@@ -469,23 +433,6 @@ function ed25519VerifierFactory(key) {
         return verify(
           null, Buffer.from(data.buffer, data.byteOffset, data.length),
           publicKey, signature);
-      }
-    };
-  }
-  if(env.nodejs) {
-    const sodium = require('sodium-native');
-    const bs58 = require('bs58');
-    const publicKey = util.base58Decode({
-      decode: bs58.decode,
-      keyMaterial: key.publicKeyBase58,
-      type: 'public'
-    });
-    return {
-      async verify({data, signature}) {
-        return sodium.crypto_sign_verify_detached(
-          Buffer.from(signature.buffer, signature.byteOffset, signature.length),
-          Buffer.from(data.buffer, data.byteOffset, data.length),
-          publicKey);
       }
     };
   }


### PR DESCRIPTION
Remove Node 10 / `sodium-native` usage, as it presents compilation problems on Windows. (Plus, no reason to support it.)